### PR TITLE
Providing noop function for wl_pointer opcode 5

### DIFF
--- a/helpers.c
+++ b/helpers.c
@@ -321,6 +321,9 @@ static void pointer_button(void *data,
         callback(button);
 }
 
+static void frame (void *data,
+    struct wl_pointer *wl_pointer) { }
+
 static void pointer_axis(void *data,
     struct wl_pointer *wl_pointer, uint32_t time,
     uint32_t axis, wl_fixed_t value) { }
@@ -330,5 +333,6 @@ static const struct wl_pointer_listener pointer_listener = {
     .leave = pointer_leave,
     .motion = pointer_motion,
     .button = pointer_button,
+    .frame = frame,
     .axis = pointer_axis
 };


### PR DESCRIPTION
Wayland compositor under WSL aborting an app, when user uses mouse with error `listener function for opcode 5 of wl_pointer is NULL`.

This code change register noop function for opcode 5 and resolves this issue.

Tested on
```
OS: Debian GNU/Linux 12 (bookworm) on Windows 10 x86_64 
Kernel: 5.15.133.1-microsoft-standard-WSL2
```

Thanks for this code example.